### PR TITLE
release: unset SKIP_WASM_BUILD for aarch64 binaries

### DIFF
--- a/.github/workflows/release-reusable-rc-buid.yml
+++ b/.github/workflows/release-reusable-rc-buid.yml
@@ -149,7 +149,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      SKIP_WASM_BUILD: 1
     steps:
       - name: Checkout sources
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0


### PR DESCRIPTION
# Description

Seems like I added `SKIP_WAS_BUILD=1` 💀  for arch64 binaries, which results in various errors like: https://github.com/paritytech/polkadot-sdk/issues/6966. This PR unsets the variable.

Closes #6966.

## Integration

People who found workarounds as in #6966 can consume the fixed binaries again.

## Review Notes

I introduced SKIP_WASM_BUILD=1 for some reason for aarch64 (probably to speed up testing) and forgot to remove it. It slipped through and interfered with `stable2412` release artifacts. Needs backporting to `stable2412` and then rebuilding/overwriting the aarch64 artifacts.